### PR TITLE
WIP: docs: add v1 migration guide and update docs for API graduation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The motivation behind the project can be found in the corresponding [RFC][0].
 - [Architecture](doc/architecture.svg)
 - [Use Stories](doc/user-stories.md)
 - [Personas](doc/personas.md)
+- [Audit Logging Guide](doc/audit-logging-guide.md)
+- [Migration Guide: API v1 Graduation](doc/migration-guide-v1.md)
 
 [0]: RFC.md
 

--- a/doc/audit-logging-guide.md
+++ b/doc/audit-logging-guide.md
@@ -58,7 +58,7 @@ This profile logs specific syscalls related to process creation.
 Create a file named `sec_comp_profile.yaml`:
 
 ```yaml
-apiVersion: security-profiles-operator.x-k8s.io/v1beta1
+apiVersion: security-profiles-operator.x-k8s.io/v1
 kind: SeccompProfile
 metadata:
   name: profile1
@@ -86,7 +86,7 @@ This will automatically apply the profile to new pods in the default namespace.
 Create a file named `image_sec_comp.yaml`:
 
 ```yaml
-apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
+apiVersion: security-profiles-operator.x-k8s.io/v1
 kind: ProfileBinding
 metadata:
   namespace: default

--- a/doc/migration-guide-v1.md
+++ b/doc/migration-guide-v1.md
@@ -1,0 +1,152 @@
+# Migration Guide: API Graduation to v1
+
+Security Profiles Operator (SPO) 1.0.0 graduates all CRD APIs from alpha/beta to v1. This document covers what changed, what happens automatically, and what you should update. For general installation and usage instructions, see [installation-usage.md](../installation-usage.md).
+
+## API version changes
+
+All SPO custom resources move to `security-profiles-operator.x-k8s.io/v1`:
+
+| CRD | Previous version(s) | New version |
+|-----|---------------------|-------------|
+| SeccompProfile | v1beta1 | v1 |
+| SelinuxProfile | v1alpha2 | v1 |
+| RawSelinuxProfile | v1alpha2 | v1 |
+| AppArmorProfile | v1alpha1 | v1 |
+| ProfileRecording | v1alpha1 | v1 |
+| ProfileBinding | v1alpha1 | v1 |
+| SecurityProfilesOperatorDaemon (SPOD) | v1alpha1 | v1 |
+| SecurityProfileNodeStatus | v1alpha1 | v1 |
+
+## Enum value changes
+
+Several enum fields changed from uppercase/lowercase to PascalCase in v1:
+
+| CRD | Field | Old value | New value |
+|-----|-------|-----------|-----------|
+| ProfileRecording | `spec.recorder` | `logs` | `Logs` |
+| ProfileRecording | `spec.recorder` | `bpf` | `Bpf` |
+| ProfileRecording | `spec.mergeStrategy` | `none` | `None` |
+| ProfileRecording | `spec.mergeStrategy` | `containers` | `Containers` |
+| SPOD | `status.state` | `PENDING` | `Pending` |
+| SPOD | `status.state` | `CREATING` | `Creating` |
+| SPOD | `status.state` | `UPDATING` | `Updating` |
+| SPOD | `status.state` | `RUNNING` | `Running` |
+| SPOD | `status.state` | `ERROR` | `Error` |
+| SPOD | `spec.enricher.logEnricherSource` | `auditd` | `Auditd` |
+| SPOD | `spec.enricher.logEnricherSource` | `bpf` | `Bpf` |
+
+## Automatic conversion
+
+Conversion webhooks handle translation between old and new API versions
+transparently. This means:
+
+- **Old manifests still work.** You can continue applying resources using
+  `v1alpha1`, `v1alpha2`, or `v1beta1` `apiVersion` values. The conversion
+  webhook translates them to v1 before storage.
+- **Old API versions are still served.** `kubectl get` with an old API version
+  returns the resource with old-style enum values, even though v1 is the
+  storage version.
+- **Existing resources in etcd are migrated on next write.** When the operator
+  upgrades, resources stored under old versions are converted to v1 the next
+  time they are updated.
+
+No data is lost during conversion. All fields are preserved across versions.
+
+## Recommended actions
+
+While automatic conversion provides backward compatibility, we recommend
+updating to v1:
+
+1. **Update YAML manifests.** Change `apiVersion` from
+   `security-profiles-operator.x-k8s.io/v1alpha1` (or `v1alpha2`, `v1beta1`)
+   to `security-profiles-operator.x-k8s.io/v1`.
+
+2. **Update enum values in manifests.** If you reference enum fields in
+   manifests or scripts, update them to PascalCase (see table above).
+
+3. **Update Go client imports.** If you consume the SPO API types in Go code,
+   update imports from `api/*/v1alpha1` to `api/*/v1`. For example:
+   ```go
+   // Before
+   import profilerecordingapi "sigs.k8s.io/security-profiles-operator/api/profilerecording/v1alpha1"
+
+   // After
+   import profilerecordingapi "sigs.k8s.io/security-profiles-operator/api/profilerecording/v1"
+   ```
+
+4. **Update scripts that parse enum strings.** If automation or monitoring
+   checks for specific enum string values (e.g., checking SPOD status for
+   `"RUNNING"`), update those checks to use PascalCase (`"Running"`).
+
+## Deprecation timeline
+
+Old API versions (`v1alpha1`, `v1alpha2`, `v1beta1`) remain served in 1.0.0
+for backward compatibility. They will be removed in a future release, at least
+one minor version after 1.0.0. Plan to migrate your manifests to v1 before
+that removal.
+
+## Examples
+
+### ProfileRecording
+
+Before (v1alpha1):
+```yaml
+apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
+kind: ProfileRecording
+metadata:
+  name: my-recording
+spec:
+  kind: SeccompProfile
+  recorder: logs
+  mergeStrategy: none
+  podSelector:
+    matchLabels:
+      app: my-app
+```
+
+After (v1):
+```yaml
+apiVersion: security-profiles-operator.x-k8s.io/v1
+kind: ProfileRecording
+metadata:
+  name: my-recording
+spec:
+  kind: SeccompProfile
+  recorder: Logs
+  mergeStrategy: None
+  podSelector:
+    matchLabels:
+      app: my-app
+```
+
+### SeccompProfile
+
+Before (v1beta1):
+```yaml
+apiVersion: security-profiles-operator.x-k8s.io/v1beta1
+kind: SeccompProfile
+metadata:
+  name: my-profile
+spec:
+  defaultAction: SCMP_ACT_ERRNO
+  syscalls:
+  - names:
+    - read
+    - write
+    action: SCMP_ACT_ALLOW
+```
+
+After (v1):
+```yaml
+apiVersion: security-profiles-operator.x-k8s.io/v1
+kind: SeccompProfile
+metadata:
+  name: my-profile
+spec:
+  defaultAction: SCMP_ACT_ERRNO
+  syscalls:
+  - names:
+    - read
+    - write
+    action: SCMP_ACT_ALLOW
+```

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -79,14 +79,17 @@
 
 The feature scope of the security-profiles-operator is right now limited to:
 
-- Adds a `SeccompProfile` CRD (alpha) to store seccomp profiles.
-- Adds a `ApparmorProfile` CRD (alpha) to store apparmor profiles.
-- Adds a `SelinuxProfile` CRD (alpha) to store apparmor profiles.
-- Adds a `ProfileBinding` CRD (alpha) to bind security profiles to pods.
-- Adds a `ProfileRecording` CRD (alpha) to record security profiles from workloads.
+- Adds a `SeccompProfile` CRD (v1) to store seccomp profiles.
+- Adds a `ApparmorProfile` CRD (v1) to store apparmor profiles.
+- Adds a `SelinuxProfile` CRD (v1) to store selinux profiles.
+- Adds a `ProfileBinding` CRD (v1) to bind security profiles to pods.
+- Adds a `ProfileRecording` CRD (v1) to record security profiles from workloads.
 - Synchronize seccomp, apparmor and selinux profiles across all worker nodes.
 - Providing metrics endpoints
 - Providing a Command Line Interface `spoc` for use cases not including Kubernetes.
+
+> **Upgrading to v1?** See the [Migration Guide](doc/migration-guide-v1.md) for
+> details on API version changes, enum normalization, and conversion webhooks.
 
 ## Architecture
 
@@ -265,12 +268,12 @@ $ kubectl -nsecurity-profiles-operator patch spod spod  --type=merge \
     -p='{"spec":{"webhook":{"options":[{"name":"binding.spo.io","namespaceSelector":{"matchExpressions":[{"key":"control-plane","operator":"DoesNotExist"}]}},{"name":"recording.spo.io","namespaceSelector":{"matchExpressions":[{"key":"control-plane","operator":"DoesNotExist"}]}}]}}}'
 ```
 
-Afterwards, validate spod has been patched successfully by ensuring the `RUNNING` state:
+Afterwards, validate spod has been patched successfully by ensuring the `Running` state:
 
 ```sh
 $ kubectl -nsecurity-profiles-operator get spod spod
 NAME   STATE
-spod   RUNNING
+spod   Running
 ```
 
 ## Configure Operator
@@ -581,16 +584,16 @@ I0623 12:51:04.258061 1854764 enricher.go:69] log-enricher "msg"="Reading from f
 ```
 
 To record by using the log enricher, create a `ProfileRecording` which is using
-`recorder: logs`:
+`recorder: Logs`:
 
 ```yaml
-apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
+apiVersion: security-profiles-operator.x-k8s.io/v1
 kind: ProfileRecording
 metadata:
   name: test-recording
 spec:
   kind: SeccompProfile
-  recorder: logs
+  recorder: Logs
   podSelector:
     matchLabels:
       app: my-app
@@ -707,16 +710,16 @@ expected. This includes a `load` and `unload` of the BPF module. If this fails,
 please open an issue so that we can find out what went wrong.
 
 To record seccomp profiles by using the BPF recorder, create a
-`ProfileRecording` which is using `recorder: bpf`:
+`ProfileRecording` which is using `recorder: Bpf`:
 
 ```yaml
-apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
+apiVersion: security-profiles-operator.x-k8s.io/v1
 kind: ProfileRecording
 metadata:
   name: my-recording
 spec:
   kind: SeccompProfile
-  recorder: bpf
+  recorder: Bpf
   podSelector:
     matchLabels:
       app: my-app
@@ -776,7 +779,7 @@ my-recording-nginx   Installed   15s
 Use the `SeccompProfile` kind to create profiles. Example:
 
 ```yaml
-apiVersion: security-profiles-operator.x-k8s.io/v1beta1
+apiVersion: security-profiles-operator.x-k8s.io/v1
 kind: SeccompProfile
 metadata:
   name: profile1
@@ -980,7 +983,7 @@ To enable a single pod log the activity following these steps:
    Create a file (e.g., profile1.yaml) with the following content:
 
    ```shell
-   apiVersion: security-profiles-operator.x-k8s.io/v1beta1
+   apiVersion: security-profiles-operator.x-k8s.io/v1
    kind: SeccompProfile
    metadata:
      name: profile1
@@ -1192,14 +1195,14 @@ You can now set up an apparmor profile recording for `nginx` container by creati
 
 ```
 kubectl apply -f - <<EOF
-apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
+apiVersion: security-profiles-operator.x-k8s.io/v1
 kind: ProfileRecording
 metadata:
   name: nginx-recording
   namespace: security-profiles-operator
 spec:
   kind: ApparmorProfile
-  recorder: bpf
+  recorder: Bpf
   podSelector:
     matchLabels:
       app: nginx
@@ -1328,7 +1331,7 @@ In particular, the `SelinuxProfile` kind:
 Below is an example of a policy that can be used with a non-privileged nginx workload:
 
 ```yaml
-apiVersion: security-profiles-operator.x-k8s.io/v1alpha2
+apiVersion: security-profiles-operator.x-k8s.io/v1
 kind: SelinuxProfile
 metadata:
   name: nginx-secure
@@ -1412,20 +1415,20 @@ I0623 12:51:04.258061 1854764 enricher.go:69] log-enricher "msg"="Reading from f
 ```
 
 To record by using the log enricher, create a `ProfileRecording` which is using
-`recorder: logs`:
+`recorder: Logs`:
 
 You can now record a SELinux profile for `nginx` container by creating the following `ProfileRecording` configuration:
 
 ```
 kubectl apply -f - <<EOF
-apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
+apiVersion: security-profiles-operator.x-k8s.io/v1
 kind: ProfileRecording
 metadata:
   name: nginx-recording
   namespace: security-profiles-operator
 spec:
   kind: SelinuxProfile
-  recorder: logs
+  recorder: Logs
   podSelector:
     matchLabels:
       app: nginx
@@ -1593,7 +1596,7 @@ application-specific profiles that only specify syscalls that are required on
 top of the base calls needed for the container runtime. For example:
 
 ```yaml
-apiVersion: security-profiles-operator.x-k8s.io/v1beta1
+apiVersion: security-profiles-operator.x-k8s.io/v1
 kind: SeccompProfile
 metadata:
   name: profile1
@@ -1659,7 +1662,7 @@ OCI artifacts, which are right now:
 To use that feature, just prefix the `baseProfileName` with `oci://`, like:
 
 ```yaml
-apiVersion: security-profiles-operator.x-k8s.io/v1beta1
+apiVersion: security-profiles-operator.x-k8s.io/v1
 kind: SeccompProfile
 metadata:
   name: profile1
@@ -1692,7 +1695,7 @@ Name:         profile1
 Labels:       spo.x-k8s.io/profile-id=SeccompProfile-profile1
 Annotations:  syscalls:
                 [{"names":["arch_prctl","brk","capget","capset","chdir","clone","close","dup3","epoll_create1","epoll_ctl","epoll_pwait","execve","exit_gr...
-API Version:  security-profiles-operator.x-k8s.io/v1beta1
+API Version:  security-profiles-operator.x-k8s.io/v1
 ```
 
 We provide all available base profiles as part of the ["Security Profiles"
@@ -1716,7 +1719,7 @@ example seccomp profile, create a ProfileBinding in the same namespace as both
 the Pod and the SeccompProfile:
 
 ```yaml
-apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
+apiVersion: security-profiles-operator.x-k8s.io/v1
 kind: ProfileBinding
 metadata:
   name: nginx-binding
@@ -1731,7 +1734,7 @@ You can enable a default profile binding by using the string "\*" as the image n
 This will only apply a profile binding if no other profile binding matches a container in the pod.
 
 ```yaml
-apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
+apiVersion: security-profiles-operator.x-k8s.io/v1
 kind: ProfileBinding
 metadata:
   name: nginx-binding
@@ -1773,7 +1776,7 @@ example uses a `SeccompProfile` as the `kind` but the same applies to
 `SelinuxProfile` as well.
 
 ```yaml
-apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
+apiVersion: security-profiles-operator.x-k8s.io/v1
 kind: ProfileRecording
 metadata:
   # The name of the Recording is the same as the resulting `SeccompProfile` CRD
@@ -1781,8 +1784,8 @@ metadata:
   name: test-recording
 spec:
   kind: SeccompProfile
-  recorder: logs
-  mergeStrategy: containers
+  recorder: Logs
+  mergeStrategy: Containers
   podSelector:
     matchLabels:
       app: sp-record
@@ -1932,7 +1935,7 @@ Now the seccomp profile should be written in the CRD format:
 ```
 
 ```yaml
-apiVersion: security-profiles-operator.x-k8s.io/v1beta1
+apiVersion: security-profiles-operator.x-k8s.io/v1
 kind: SeccompProfile
 metadata:
   name: echo

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -169,6 +169,10 @@ func (e *e2e) TestSecurityProfilesOperator() {
 			"SPOD: Enable profile recorder",
 			e.testCaseSPODEnableProfileRecorder,
 		},
+		{
+			"API v1 Graduation: Verify conversion webhooks",
+			e.testCaseAPIV1Graduation,
+		},
 	}
 	for _, testCase := range testCases {
 		tc := testCase

--- a/test/tc_api_v1_graduation_test.go
+++ b/test/tc_api_v1_graduation_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"encoding/json"
+)
+
+func (e *e2e) testCaseAPIV1Graduation(_ []string) {
+	e.seccompOnlyTestCase()
+
+	e.logf("Testing API v1 graduation conversion webhooks")
+
+	e.testSeccompProfileConversion()
+	e.testProfileRecordingConversion()
+}
+
+func (e *e2e) testSeccompProfileConversion() {
+	e.logf("Testing SeccompProfile v1beta1 -> v1 conversion")
+
+	const (
+		v1beta1Profile = `
+apiVersion: security-profiles-operator.x-k8s.io/v1beta1
+kind: SeccompProfile
+metadata:
+  name: test-v1beta1-conversion
+spec:
+  defaultAction: "SCMP_ACT_ERRNO"
+  syscalls:
+  - names:
+    - read
+    - write
+    - exit_group
+    action: "SCMP_ACT_ALLOW"
+`
+		profileName = "test-v1beta1-conversion"
+	)
+
+	cleanup := e.writeAndCreate(v1beta1Profile, "v1beta1-seccomp-*.yaml")
+	defer cleanup()
+
+	e.logf("Waiting for v1beta1 SeccompProfile to be reconciled")
+	e.waitForProfile(profileName)
+
+	e.logf("Verifying v1beta1 profile is accessible via v1 API")
+	sp := e.getSeccompProfile(profileName)
+	e.Equal("SCMP_ACT_ERRNO", string(sp.Spec.DefaultAction))
+	e.Require().NotEmpty(sp.Spec.Syscalls)
+	e.Equal("SCMP_ACT_ALLOW", string(sp.Spec.Syscalls[0].Action))
+	e.Contains(sp.Spec.Syscalls[0].Names, "read")
+	e.Contains(sp.Spec.Syscalls[0].Names, "write")
+	e.Contains(sp.Spec.Syscalls[0].Names, "exit_group")
+
+	e.logf("Verifying round-trip back to v1beta1")
+	v1beta1JSON := e.kubectl(
+		"get",
+		"seccompprofiles.v1beta1.security-profiles-operator.x-k8s.io",
+		profileName, "-o", "json",
+	)
+
+	var v1beta1Result map[string]interface{}
+	e.Require().NoError(json.Unmarshal([]byte(v1beta1JSON), &v1beta1Result))
+
+	spec, ok := v1beta1Result["spec"].(map[string]interface{})
+	e.Require().True(ok, "spec should be a map")
+	e.Equal("SCMP_ACT_ERRNO", spec["defaultAction"])
+
+	syscalls, ok := spec["syscalls"].([]interface{})
+	e.Require().True(ok, "syscalls should be a list")
+	e.Require().NotEmpty(syscalls)
+
+	firstSyscall, ok := syscalls[0].(map[string]interface{})
+	e.Require().True(ok)
+	e.Equal("SCMP_ACT_ALLOW", firstSyscall["action"])
+
+	e.logf("SeccompProfile v1beta1 <-> v1 conversion verified")
+
+	e.kubectl("delete", "seccompprofile", profileName)
+}
+
+func (e *e2e) testProfileRecordingConversion() {
+	e.logf("Testing ProfileRecording v1alpha1 -> v1 enum conversion")
+
+	const (
+		v1alpha1Recording = `
+apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
+kind: ProfileRecording
+metadata:
+  name: test-v1alpha1-conversion
+spec:
+  kind: SeccompProfile
+  recorder: logs
+  mergeStrategy: none
+  podSelector:
+    matchLabels:
+      app: test-recording
+`
+		recordingName = "test-v1alpha1-conversion"
+	)
+
+	cleanup := e.writeAndCreate(v1alpha1Recording, "v1alpha1-recording-*.yaml")
+	defer cleanup()
+
+	e.logf("Verifying v1alpha1 recording is accessible via v1 API with PascalCase enums")
+	v1JSON := e.kubectl("get", "profilerecording", recordingName, "-o", "json")
+
+	var v1Result map[string]interface{}
+	e.Require().NoError(json.Unmarshal([]byte(v1JSON), &v1Result))
+
+	spec, ok := v1Result["spec"].(map[string]interface{})
+	e.Require().True(ok, "spec should be a map")
+	e.Equal("Logs", spec["recorder"], "v1 recorder should be PascalCase 'Logs'")
+	e.Equal("None", spec["mergeStrategy"], "v1 mergeStrategy should be PascalCase 'None'")
+	e.Equal("SeccompProfile", spec["kind"], "kind should be preserved")
+
+	e.logf("Verifying round-trip back to v1alpha1 with lowercase enums")
+	v1alpha1JSON := e.kubectl(
+		"get",
+		"profilerecordings.v1alpha1.security-profiles-operator.x-k8s.io",
+		recordingName, "-o", "json",
+	)
+
+	var v1alpha1Result map[string]interface{}
+	e.Require().NoError(json.Unmarshal([]byte(v1alpha1JSON), &v1alpha1Result))
+
+	spec, ok = v1alpha1Result["spec"].(map[string]interface{})
+	e.Require().True(ok, "spec should be a map")
+	e.Equal("logs", spec["recorder"], "v1alpha1 recorder should be lowercase 'logs'")
+	e.Equal("none", spec["mergeStrategy"], "v1alpha1 mergeStrategy should be lowercase 'none'")
+
+	e.logf("ProfileRecording v1alpha1 <-> v1 enum conversion verified")
+
+	e.kubectl("delete", "profilerecording", recordingName)
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Adds a migration guide and e2e tests for the v1 API graduation on top of #3242.
- Add `doc/migration-guide-v1.md` covering API version changes, enum casing normalization, conversion webhooks, recommended actions, and deprecation timeline
- Add e2e tests verifying SeccompProfile v1beta1 round-trip and ProfileRecording v1alpha1 enum conversion through conversion webhooks
- Update `installation-usage.md` and `doc/audit-logging-guide.md` to use v1 apiVersion references and PascalCase enum values
- Link all docs from README.md and cross-reference correctly

#### Which issue(s) this PR fixes:

Fixes kubernetes-sigs/security-profiles-operator#3195

#### Does this PR have test?

Yes, `test/tc_api_v1_graduation_test.go` with conversion webhook round-trip tests.

#### Special notes for your reviewer:

Based on the `api/v1-graduation` branch (kubernetes-sigs#3242).

#### Does this PR introduce a user-facing change?

```release-note
Add migration guide for API graduation to v1 with conversion webhook e2e tests.
```